### PR TITLE
feat: add `lists create` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ attio config claude-md >> CLAUDE.md
 | **Lists** | |
 | `attio lists list` | List all lists |
 | `attio lists get <id>` | Get a specific list |
+| `attio lists create` | Create a new list |
 | **Entries** | |
 | `attio entries list <list>` | List entries in a list |
 | `attio entries get <list> <id>` | Get a specific entry |

--- a/src/commands/entries.ts
+++ b/src/commands/entries.ts
@@ -101,7 +101,7 @@ export function register(program: Command): void {
       const client = new AttioClient(opts.apiKey, opts.debug);
       const format: OutputFormat = detectFormat(opts);
 
-      const resolvedValues = requireValues(await resolveValues({ values: opts.values, set: opts.set }));
+      const resolvedValues = await resolveValues({ values: opts.values, set: opts.set });
 
       const body: any = {
         data: {
@@ -135,7 +135,7 @@ export function register(program: Command): void {
       const client = new AttioClient(opts.apiKey, opts.debug);
       const format: OutputFormat = detectFormat(opts);
 
-      const resolvedValues = requireValues(await resolveValues({ values: opts.values, set: opts.set }));
+      const resolvedValues = await resolveValues({ values: opts.values, set: opts.set });
 
       const body: any = {
         data: {

--- a/src/commands/lists.ts
+++ b/src/commands/lists.ts
@@ -45,6 +45,75 @@ export function register(program: Command): void {
     });
 
   cmd
+    .command('create')
+    .description('Create a new list')
+    .requiredOption('--name <name>', 'Human-readable name for the list')
+    .requiredOption('--parent-object <object>', 'Object slug or ID for records in this list (e.g. "people", "companies")')
+    .option('--api-slug <slug>', 'API slug in snake_case (auto-generated from name if omitted)')
+    .option(
+      '--workspace-access <level>',
+      'Access for all workspace members: full-access, read-and-write, read-only',
+      'full-access',
+    )
+    .option(
+      '--member-access <member-id:level>',
+      'Grant access to a specific member as member-id:level (repeatable)',
+      (val: string, prev: string[]) => [...prev, val],
+      [] as string[],
+    )
+    .action(async (_options: any, command: Command) => {
+      const opts = command.optsWithGlobals();
+      const client = new AttioClient(opts.apiKey, opts.debug);
+      const format: OutputFormat = detectFormat(opts);
+
+      const apiSlug = opts.apiSlug || opts.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+
+      const memberAccess = (opts.memberAccess as string[]).map((entry: string) => {
+        const colonIdx = entry.lastIndexOf(':');
+        if (colonIdx === -1) {
+          throw new Error(`Invalid --member-access format: "${entry}". Expected: member-id:level`);
+        }
+        return {
+          workspace_member_id: entry.slice(0, colonIdx),
+          level: entry.slice(colonIdx + 1),
+        };
+      });
+
+      const body = {
+        data: {
+          name: opts.name,
+          api_slug: apiSlug,
+          parent_object: opts.parentObject,
+          workspace_access: opts.workspaceAccess,
+          workspace_member_access: memberAccess,
+        },
+      };
+
+      const res = await client.post<{ data: any }>('/lists', body);
+      const listData = res.data;
+
+      if (format === 'quiet') {
+        console.log(listData.id?.list_id ?? '');
+        return;
+      }
+
+      if (format === 'json') {
+        outputSingle(listData, { format, idField: 'id' });
+        return;
+      }
+
+      const flat: Record<string, any> = {
+        id: listData.id?.list_id || '',
+        api_slug: listData.api_slug || '',
+        name: listData.name || '',
+        parent_object: listData.parent_object || '',
+        workspace_access: listData.workspace_access || '',
+      };
+
+      outputSingle(flat, { format, idField: 'id' });
+    });
+
+  cmd
     .command('get <list>')
     .description('Get a list by ID or slug')
     .action(async (list: string, _options: any, command: Command) => {

--- a/tests/entries-empty-values.test.ts
+++ b/tests/entries-empty-values.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { register as registerEntries } from '../src/commands/entries.ts';
+import { createProgram, installFetchMock, runCli } from './cli-test-helpers.ts';
+
+test('entries create succeeds with empty entry_values', async () => {
+  const program = createProgram([registerEntries]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: {
+        id: { entry_id: 'ent_new' },
+        record_id: 'rec_1',
+        created_at: '2026-02-19T00:00:00.000Z',
+        entry_values: {},
+      },
+    },
+  }));
+
+  try {
+    await runCli(program, [
+      'entries', 'create', 'my_list',
+      '--record', 'rec_1',
+      '--object', 'companies',
+      '--values', '{}',
+    ]);
+
+    const call = mock.calls.find((c) => c.method === 'POST' && c.url.includes('/lists/my_list/entries'));
+    assert.ok(call, 'Expected POST /lists/my_list/entries call');
+    assert.equal(call.body?.data?.parent_record_id, 'rec_1');
+    assert.equal(call.body?.data?.parent_object, 'companies');
+    assert.deepEqual(call.body?.data?.entry_values, {});
+  } finally {
+    mock.restore();
+  }
+});
+
+test('entries assert succeeds with empty entry_values', async () => {
+  const program = createProgram([registerEntries]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: {
+        id: { entry_id: 'ent_upserted' },
+        record_id: 'rec_1',
+        created_at: '2026-02-19T00:00:00.000Z',
+        entry_values: {},
+      },
+    },
+  }));
+
+  try {
+    await runCli(program, [
+      'entries', 'assert', 'my_list',
+      '--record', 'rec_1',
+      '--object', 'companies',
+      '--values', '{}',
+    ]);
+
+    const call = mock.calls.find((c) => c.method === 'PUT' && c.url.includes('/lists/my_list/entries'));
+    assert.ok(call, 'Expected PUT /lists/my_list/entries call');
+    assert.equal(call.body?.data?.parent_record_id, 'rec_1');
+    assert.equal(call.body?.data?.parent_object, 'companies');
+    assert.deepEqual(call.body?.data?.entry_values, {});
+  } finally {
+    mock.restore();
+  }
+});
+
+test('entries create still works with --set values', async () => {
+  const program = createProgram([registerEntries]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: {
+        id: { entry_id: 'ent_with_vals' },
+        record_id: 'rec_1',
+        created_at: '2026-02-19T00:00:00.000Z',
+        entry_values: {},
+      },
+    },
+  }));
+
+  try {
+    await runCli(program, [
+      'entries', 'create', 'pipeline',
+      '--record', 'rec_1',
+      '--object', 'companies',
+      '--set', 'stage=qualified',
+    ]);
+
+    const call = mock.calls.find((c) => c.method === 'POST' && c.url.includes('/lists/pipeline/entries'));
+    assert.ok(call, 'Expected POST /lists/pipeline/entries call');
+    assert.equal(call.body?.data?.entry_values?.stage, 'qualified');
+  } finally {
+    mock.restore();
+  }
+});

--- a/tests/lists.test.ts
+++ b/tests/lists.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { register as registerLists } from '../src/commands/lists.ts';
+import { createProgram, installFetchMock, runCli, assertCalledPath } from './cli-test-helpers.ts';
+
+test('lists create sends POST /lists with correct body', async () => {
+  const program = createProgram([registerLists]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: {
+        id: { list_id: 'list_abc123' },
+        api_slug: 'enterprise_sales',
+        name: 'Enterprise Sales',
+        parent_object: 'companies',
+        workspace_access: 'full-access',
+        workspace_member_access: [],
+        created_by_actor: { type: 'workspace-member', id: 'mem_1' },
+      },
+    },
+  }));
+
+  try {
+    await runCli(program, [
+      'lists', 'create',
+      '--name', 'Enterprise Sales',
+      '--parent-object', 'companies',
+    ]);
+
+    const call = mock.calls.find((c) => c.method === 'POST' && c.url.includes('/lists'));
+    assert.ok(call, 'Expected POST /lists call');
+    assert.equal(call.body?.data?.name, 'Enterprise Sales');
+    assert.equal(call.body?.data?.parent_object, 'companies');
+    assert.equal(call.body?.data?.api_slug, 'enterprise_sales');
+    assert.equal(call.body?.data?.workspace_access, 'full-access');
+    assert.deepEqual(call.body?.data?.workspace_member_access, []);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('lists create uses explicit --api-slug when provided', async () => {
+  const program = createProgram([registerLists]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: {
+        id: { list_id: 'list_abc123' },
+        api_slug: 'my_custom_slug',
+        name: 'Enterprise Sales',
+        parent_object: 'people',
+        workspace_access: 'read-only',
+        workspace_member_access: [],
+      },
+    },
+  }));
+
+  try {
+    await runCli(program, [
+      'lists', 'create',
+      '--name', 'Enterprise Sales',
+      '--parent-object', 'people',
+      '--api-slug', 'my_custom_slug',
+      '--workspace-access', 'read-only',
+    ]);
+
+    const call = mock.calls.find((c) => c.method === 'POST' && c.url.includes('/lists'));
+    assert.ok(call, 'Expected POST /lists call');
+    assert.equal(call.body?.data?.api_slug, 'my_custom_slug');
+    assert.equal(call.body?.data?.workspace_access, 'read-only');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('lists create with --member-access parses member-id:level', async () => {
+  const program = createProgram([registerLists]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: {
+        id: { list_id: 'list_abc123' },
+        api_slug: 'test_list',
+        name: 'Test List',
+        parent_object: 'companies',
+        workspace_access: 'full-access',
+        workspace_member_access: [
+          { workspace_member_id: 'mem_1', level: 'read-and-write' },
+        ],
+      },
+    },
+  }));
+
+  try {
+    await runCli(program, [
+      'lists', 'create',
+      '--name', 'Test List',
+      '--parent-object', 'companies',
+      '--member-access', 'mem_1:read-and-write',
+    ]);
+
+    const call = mock.calls.find((c) => c.method === 'POST' && c.url.includes('/lists'));
+    assert.ok(call, 'Expected POST /lists call');
+    assert.deepEqual(call.body?.data?.workspace_member_access, [
+      { workspace_member_id: 'mem_1', level: 'read-and-write' },
+    ]);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('lists list sends GET /lists', async () => {
+  const program = createProgram([registerLists]);
+  const mock = installFetchMock(async () => ({
+    body: {
+      data: [
+        {
+          id: { list_id: 'list_1' },
+          api_slug: 'sales',
+          name: 'Sales',
+          parent_object: 'companies',
+        },
+      ],
+    },
+  }));
+
+  try {
+    await runCli(program, ['lists', 'list']);
+    assertCalledPath(mock.calls, '/lists', 'GET');
+  } finally {
+    mock.restore();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `attio lists create` subcommand that calls `POST /v2/lists` to create new lists
- Supports `--name`, `--parent-object` (required), plus optional `--api-slug`, `--workspace-access`, and repeatable `--member-access` flags
- Auto-generates `api_slug` from the name in snake_case when not explicitly provided
- **Fixes #3**: allows `entries create` and `entries assert` to proceed with empty `entry_values` when the list has no custom writable attributes

## Usage

```bash
# Minimal: create a list for companies
attio lists create --name "Enterprise Sales" --parent-object companies

# With custom slug and access level
attio lists create --name "Enterprise Sales" --parent-object companies \
  --api-slug my_sales_list --workspace-access read-and-write

# With per-member access
attio lists create --name "Private Pipeline" --parent-object companies \
  --member-access "50cf242c-7fa3-4cad-87d0-75b1af71c57b:full-access"

# Quiet mode for scripting
LIST_ID=$(attio lists create --name "New Pipeline" --parent-object deals -q)

# Add a record to a list with no custom attributes (previously failed)
attio entries create my_list --record <record-id> --object companies
```

## Test plan

- [x] 4 new unit tests for `lists create` in `tests/lists.test.ts`
- [x] 3 new unit tests for entries empty values fix in `tests/entries-empty-values.test.ts`
- [x] All 32 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual test against live Attio workspace