### PR TITLE
fix(entries): allow create/assert with no entry values

### DIFF
--- a/src/commands/entries.ts
+++ b/src/commands/entries.ts
@@ -101,7 +101,7 @@ export function register(program: Command): void {
       const client = new AttioClient(opts.apiKey, opts.debug);
       const format: OutputFormat = detectFormat(opts);
 
-      const resolvedValues = requireValues(await resolveValues({ values: opts.values, set: opts.set }));
+      const resolvedValues = await resolveValues({ values: opts.values, set: opts.set });
 
       const body: any = {
         data: {
@@ -135,7 +135,7 @@ export function register(program: Command): void {
       const client = new AttioClient(opts.apiKey, opts.debug);
       const format: OutputFormat = detectFormat(opts);
 
-      const resolvedValues = requireValues(await resolveValues({ values: opts.values, set: opts.set }));
+      const resolvedValues = await resolveValues({ values: opts.values, set: opts.set });
 
       const body: any = {
         data: {

--- a/tests/values.test.ts
+++ b/tests/values.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { parseSets } from '../src/values.ts';
+import { parseSets, resolveValues } from '../src/values.ts';
 
 test('parseSets supports empty array shorthand', () => {
   assert.deepEqual(parseSets(['tags=[]']), { tags: [] });
@@ -16,4 +16,9 @@ test('parseSets supports shorthand arrays', () => {
   assert.deepEqual(parseSets(['tags=[alpha,2,true]']), {
     tags: ['alpha', 2, true],
   });
+});
+
+test('resolveValues returns empty object for empty JSON', async () => {
+  const result = await resolveValues({ values: '{}', set: [] });
+  assert.deepEqual(result, {});
 });


### PR DESCRIPTION
## Summary

- `entries create` and `entries assert` were rejecting calls with no `--set`/`--values` flags, even though the Attio API accepts `entry_values: {}` (valid for lists with no custom attributes)
- Removed the `requireValues()` guard from these two commands so they pass `entry_values: {}` through to the API when no values are provided
- `requireValues` is still enforced on `entries update` and all `records` commands where empty input is genuinely invalid

## Test plan

- [x] `attio entries create <list> --record <id> --object <object>` succeeds without `--set` or `--values`
- [x] `attio entries assert <list> --record <id> --object <object>` succeeds without `--set` or `--values`
- [x] `attio entries update` still rejects empty values
- [x] Unit test: `resolveValues({ values: '{}', set: [] })` returns `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)